### PR TITLE
Update install.R so command library(InterMineR) works

### DIFF
--- a/install.R
+++ b/install.R
@@ -1,3 +1,4 @@
+install.packages("XML")
 install.packages("BiocManager")
 BiocManager::install("InterMineR")
 BiocManager::install("GeneAnswers")


### PR DESCRIPTION
If you run the current binder script for Workshop Workflow PAX6-unsolved.ipynb, library(InterMineR) doesn't work
If you create a new cell above and run BiocManager::install("InterMineR") the message several lines below occurs...
So I tried adding install.packages("XML") and running that before BiocManager::install("InterMineR") and then library(InterMineR) works

So it is only logical that modifying install.R would fix the problem.

"Bioconductor version 3.10 (BiocManager 1.30.4), R 3.6.3 (2020-02-29)

Installing package(s) 'InterMineR'

Warning message:
“dependency ‘XML’ is not available”
Warning message in install.packages(pkgs = doing, lib = lib, repos = repos, ...):
“installation of package ‘InterMineR’ had non-zero exit status”
installation path not writeable, unable to update packages: nlme, spatial,
  survival

Update old packages: 'BH', 'BiocManager', 'curl', 'devtools', 'git2r',
  'httpuv', 'httr', 'later', 'mime', 'openssl', 'promises', 'R6', 'Rcpp',
  'rstudioapi', 'shiny', 'whisker', 'withr'"